### PR TITLE
feat: brighten site color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     </div>
   </header>
 
-  <section id="about" class="py-20 px-4 fade-in bg-[#7EBFD9] text-[#1B3059]">
+  <section id="about" class="py-20 px-4 fade-in bg-[#4DD0E1] text-[#0D47A1]">
     <div class="container mx-auto">
       <h2 class="text-3xl font-bold mb-6 text-center">Sobre mí</h2>
       <p class="max-w-3xl mx-auto text-center">Soy un desarrollador web apasionado por transformar ideas en experiencias digitales atractivas. Me especializo en HTML, CSS, JavaScript y React, siempre buscando optimizar el rendimiento y la experiencia de usuario. Mi objetivo es aportar soluciones creativas y funcionales que ayuden a las personas y empresas a destacar en el mundo digital.</p>
@@ -89,15 +89,15 @@
     </div>
   </section>
 
-  <section id="contact" class="py-20 fade-in bg-[#1B3059] text-white">
+  <section id="contact" class="py-20 fade-in bg-[#0D47A1] text-white">
     <div class="container mx-auto px-4">
       <h2 class="text-3xl font-bold mb-4 text-center">Contacto</h2>
       <p class="text-center mb-8">¿Tienes un proyecto o idea en mente? ¡Hablemos!</p>
       <form class="max-w-xl mx-auto space-y-4">
-        <input type="text" placeholder="Tu nombre completo" required class="w-full p-3 border border-[#2976A6] rounded-lg bg-white text-[#1B3059]" />
-        <input type="email" placeholder="Tu correo electrónico" required class="w-full p-3 border border-[#2976A6] rounded-lg bg-white text-[#1B3059]" />
-        <textarea placeholder="Escribe tu mensaje aquí..." required class="w-full p-3 border border-[#2976A6] rounded-lg bg-white text-[#1B3059] h-32"></textarea>
-        <button type="submit" class="w-full py-3 bg-[#D93814] text-white rounded-lg shadow hover:bg-[#D98032]">Enviar Mensaje</button>
+        <input type="text" placeholder="Tu nombre completo" required class="w-full p-3 border border-[#00BCD4] rounded-lg bg-white text-[#0D47A1]" />
+        <input type="email" placeholder="Tu correo electrónico" required class="w-full p-3 border border-[#00BCD4] rounded-lg bg-white text-[#0D47A1]" />
+        <textarea placeholder="Escribe tu mensaje aquí..." required class="w-full p-3 border border-[#00BCD4] rounded-lg bg-white text-[#0D47A1] h-32"></textarea>
+        <button type="submit" class="w-full py-3 bg-[#FF5722] text-white rounded-lg shadow hover:bg-[#FF9800]">Enviar Mensaje</button>
       </form>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
 }
 
 .btn-primario {
-  background-color: #D93814;
+  background-color: #FF5722;
   color: #fff;
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem;
@@ -17,22 +17,22 @@ body {
 }
 
 .btn-primario:hover {
-  background-color: #D98032;
+  background-color: #FF9800;
 }
 
 .habilidad {
-  background-color: #D98032;
+  background-color: #FF9800;
   color: #fff;
   transition: background-color 0.3s ease;
   text-align: center;
 }
 
 .habilidad:hover {
-  background-color: #2976A6;
+  background-color: #00BCD4;
 }
 
 .btn-proyecto {
-  background-color: #2976A6;
+  background-color: #00BCD4;
   color: #fff;
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
@@ -41,7 +41,7 @@ body {
 }
 
 .btn-proyecto:hover {
-  background-color: #1B3059;
+  background-color: #00838F;
 }
 
 .fade-in {


### PR DESCRIPTION
## Summary
- refresh primary, skill, and project button styles with vibrant orange and cyan tones
- energize About and Contact sections and form elements with matching lively colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd3cb7088323a563d83d12319640