### PR TITLE
Add additional skill cards and icons

### DIFF
--- a/icons/adobe.svg
+++ b/icons/adobe.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="4" fill="none"/>
+  <text x="12" y="16" font-size="14" text-anchor="middle" fill="#ffffff" font-family="sans-serif">A</text>
+</svg>

--- a/icons/blender.svg
+++ b/icons/blender.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="4" fill="none"/>
+  <text x="12" y="16" font-size="14" text-anchor="middle" fill="#ffffff" font-family="sans-serif">B</text>
+</svg>

--- a/icons/python.svg
+++ b/icons/python.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="4" fill="none"/>
+  <text x="12" y="16" font-size="14" text-anchor="middle" fill="#ffffff" font-family="sans-serif">Py</text>
+</svg>

--- a/icons/unity.svg
+++ b/icons/unity.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="4" fill="none"/>
+  <text x="12" y="16" font-size="14" text-anchor="middle" fill="#ffffff" font-family="sans-serif">U</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,26 @@
           <h3 class="font-semibold mb-1">React</h3>
           <p class="text-sm">Interfaces de usuario modernas y eficientes.</p>
         </div>
+        <div class="habilidad flex flex-col items-center">
+          <img src="icons/adobe.svg" alt="Adobe Creative Cloud" class="w-12 h-12 mb-3" />
+          <h3 class="font-semibold mb-1">Adobe Creative Cloud</h3>
+          <p class="text-sm">Diseño y edición profesional con Photoshop, Illustrator, Premiere, After Effects y más.</p>
+        </div>
+        <div class="habilidad flex flex-col items-center">
+          <img src="icons/blender.svg" alt="Blender" class="w-12 h-12 mb-3" />
+          <h3 class="font-semibold mb-1">Blender</h3>
+          <p class="text-sm">Modelado 3D, animación y renderizado realista.</p>
+        </div>
+        <div class="habilidad flex flex-col items-center">
+          <img src="icons/unity.svg" alt="Unity" class="w-12 h-12 mb-3" />
+          <h3 class="font-semibold mb-1">Unity</h3>
+          <p class="text-sm">Desarrollo de videojuegos multiplataforma.</p>
+        </div>
+        <div class="habilidad flex flex-col items-center">
+          <img src="icons/python.svg" alt="Python" class="w-12 h-12 mb-3" />
+          <h3 class="font-semibold mb-1">Python</h3>
+          <p class="text-sm">Programación versátil para automatización, análisis de datos y desarrollo web.</p>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Extend skills grid with cards for Adobe Creative Cloud, Blender, Unity, and Python.
- Include lightweight white icons for each new skill.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f04db318832389b7993229b10ffc